### PR TITLE
Update container-registry-auth-aci.md for removing private keyword

### DIFF
--- a/articles/container-registry/container-registry-auth-aci.md
+++ b/articles/container-registry/container-registry-auth-aci.md
@@ -1,6 +1,6 @@
 ---
-title: Access Private Registry Images from ACI
-description: Learn how to provide access to images in your private container registry from Azure Container Instances by using a Microsoft Entra service principal.
+title: Access Registry Images from ACI
+description: Learn how to provide access to images in your container registry from Azure Container Instances by using a Microsoft Entra service principal.
 ms.topic: conceptual
 ms.custom: devx-track-azurecli
 ms.service: azure-container-registry
@@ -11,9 +11,9 @@ ms.date: 10/31/2023
 
 # Authenticate with Azure Container Registry from Azure Container Instances
 
-You can use a Microsoft Entra service principal to provide access to your private container registries in Azure Container Registry.
+You can use a Microsoft Entra service principal to provide access to your container registries in Azure Container Registry.
 
-In this article, you learn to create and configure a Microsoft Entra service principal with *pull* permissions to your registry. Then, you start a container in Azure Container Instances (ACI) that pulls its image from your private registry, using the service principal for authentication.
+In this article, you learn to create and configure a Microsoft Entra service principal with *pull* permissions to your registry. Then, you start a container in Azure Container Instances (ACI) that pulls its image from your registry, using the service principal for authentication.
 
 ## When to use a service principal
 


### PR DESCRIPTION
SP only works for public ACR. The original page may be confusing to users.
- network setting with the following
![image](https://github.com/user-attachments/assets/509ff23a-28cf-469a-9c19-74ac8a98a4a0)
- Then, SP shows error
![image](https://github.com/user-attachments/assets/089a58c7-74c6-4bb9-8eb8-2bd5c21d14d3)

MI could work for private ACR (public access limited https://learn.microsoft.com/en-us/azure/container-registry/allow-access-trusted-services#trusted-services)
- Same network setting, and it works.
![image](https://github.com/user-attachments/assets/d3cee2b1-6e99-41a0-9abc-97673d53869c)
